### PR TITLE
Add Synapse Integration test, Update Github CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - updateci
 
 jobs:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           python -m pip install pipenv
           pipenv install --dev
           short_sha=${GITHUB_SHA::8}
-          echo "::set-env name=SHORT_SHA::$short_sha"
+          echo "SHORT_SHA=${short_sha}" >> $GITHUB_ENV
 
           # create synapse config file for integration test
           OUTPUT_FILE=/tmp/.synapseConfig

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - updateci
 
 jobs:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - ci_integration_test_example
+      - updateci
 
 jobs:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - ci_integration_test_example
 
 jobs:
 
@@ -29,6 +30,15 @@ jobs:
           short_sha=${GITHUB_SHA::8}
           echo "::set-env name=SHORT_SHA::$short_sha"
 
+          # create synapse config file for integration test
+          OUTPUT_FILE=/tmp/.synapseConfig
+          cat > "$OUTPUT_FILE" << EOM
+          [authentication]
+          username = "${{secrets.SYNAPSE_USERNAME }}"
+          apikey = "${{secrets.SYNAPSE_API_KEY }}"
+          EOM
+          chmod +x "$OUTPUT_FILE"
+
       - name: Test CWL
         id: test_cwl
         run: |
@@ -37,6 +47,7 @@ jobs:
   tag:
     if: "!contains(github.event.head_commit.message, '[skip-ci]')"
     runs-on: ubuntu-latest
+    needs: test
     steps:
 
       - name: Git Checkout

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ workflow, subworkflows, and tests for publication on Dockstore (the last coming 
 ## CWL
 
 The example main workflow file, `main.cwl`, if placed at the root of the
-repository. The placeholder workflow includes another workflow as a step from
+repository. There is also a `main2.cwl` workflow that can be used to download 
+data files from [Synapse](https://www.synapse.org/). The placeholder workflow includes another workflow as a step from
 the `subworkflows` directory. The subworkflow has an example of using a
 versioned tool from another repository.
 
@@ -24,7 +25,7 @@ added requires a file describing the job inputs that should be added to the
 
 ### Integration Tests
 While unit tests are recommended, if an integration test is needed, there is an
-example available in the [ci_integration_test_example branch](https://github.com/Sage-Bionetworks-Workflows/cwl-workflow-template/tree/ci_integration_test_example) of this repository.
+example available in the [updateci](https://github.com/Sage-Bionetworks-Workflows/cwl-workflow-template/tree/updateci) of this repository.
 In this example, the workflow is dependent on a file that contains an API key to
 connect to Synapse, an outside service. The Synapse user name and api key are
 stored as secrets in this repository. The example shows how those secrets are

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ added requires a file describing the job inputs that should be added to the
 
 ### Integration Tests
 While unit tests are recommended, if an integration test is needed, there is an
-example available in the [updateci](https://github.com/Sage-Bionetworks-Workflows/cwl-workflow-template/tree/updateci) of this repository.
+example available in the [updateci branch](https://github.com/Sage-Bionetworks-Workflows/cwl-workflow-template/tree/updateci) of this repository.
 In this example, the workflow is dependent on a file that contains an API key to
 connect to Synapse, an outside service. The Synapse user name and api key are
 stored as secrets in this repository. The example shows how those secrets are

--- a/main2.cwl
+++ b/main2.cwl
@@ -1,0 +1,26 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+
+inputs:
+  synapseid:
+    type: string
+  synapse_config:
+    type: File
+
+outputs:
+  file:
+    type: File
+    outputSource: synget/filepath
+
+requirements:
+  SubworkflowFeatureRequirement: {}
+
+steps:
+  synget:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/synapse-client-cwl-tools/v0.1/synapse-get-tool.cwl
+    in:
+      synapseid: synapseid
+      synapse_config: synapse_config
+    out: [filepath]

--- a/subworkflows/echo-workflow.cwl
+++ b/subworkflows/echo-workflow.cwl
@@ -13,7 +13,7 @@ outputs:
 
 steps:
   echo:
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-template/v0.0.1/cwl/echo.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-tool-template/main/cwl/echo.cwl
     in:
       message: message
     out: [out]

--- a/subworkflows/echo-workflow.cwl
+++ b/subworkflows/echo-workflow.cwl
@@ -13,7 +13,7 @@ outputs:
 
 steps:
   echo:
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-workflow-template/v0.0.6/subworkflows/echo-workflow.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-tool-template/v0.0.16/cwl/echo.cwl
     in:
       message: message
     out: [out]

--- a/subworkflows/echo-workflow.cwl
+++ b/subworkflows/echo-workflow.cwl
@@ -13,7 +13,7 @@ outputs:
 
 steps:
   echo:
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-tool-template/main/cwl/echo.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-workflow-template/v0.0.6/subworkflows/echo-workflow.cwl
     in:
       message: message
     out: [out]

--- a/tests/syn_hello_world.yaml
+++ b/tests/syn_hello_world.yaml
@@ -1,0 +1,4 @@
+synapseid: syn22106326
+synapse_config:
+  class: File
+  path: '/tmp/.synapseConfig'

--- a/tests/test-descriptions.yaml
+++ b/tests/test-descriptions.yaml
@@ -5,3 +5,15 @@
   label: workflow_example_test
   id: 0
   doc: Placeholder test
+- job: syn_hello_world.yaml
+  output:
+    "file": {
+      "checksum": "sha1$60fde9c2310b0d4cad4dab8d126b04387efba289",
+      "class": "File",
+      "location": "hello_world.txt",
+      "size": 14
+    }
+  tool: ../main2.cwl
+  label: synapse_integration_test
+  id: 1
+  doc: Example of an integration test that uses Synapse


### PR DESCRIPTION
- Addition of main2.cwl, which tests the functionality of testing using synapse downloads
- Updated deprecated command in the Github CI